### PR TITLE
Use proper dataset for Run2015D DoubleEG

### DIFF
--- a/datasets/data_Run2015D.json
+++ b/datasets/data_Run2015D.json
@@ -13,8 +13,8 @@
     "era": "25ns",
     "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
   },
-  "/DoubleEG/Run2015D-16Dec2015-v1/MINIAOD": {
-    "name": "DoubleEG_Run2015D-16Dec2015-v1_2015-12-18",
+  "/DoubleEG/Run2015D-16Dec2015-v2/MINIAOD": {
+    "name": "DoubleEG_Run2015D-16Dec2015-v2_2015-12-18",
     "units_per_job": 300,
     "run_range": [256630, 260627],
     "era": "25ns",


### PR DESCRIPTION
DoubleEG is in fact available in 7.6.x, the dataset we were using was not the right one (`v1` vs `v2`) ...
