### PR TITLE
Updated JSON for rereco and adjusted splitting

### DIFF
--- a/datasets/data_Run2015D.json
+++ b/datasets/data_Run2015D.json
@@ -1,23 +1,23 @@
 {
   "/MuonEG/Run2015D-16Dec2015-v1/MINIAOD": {
-    "name": "MuonEG_Run2015D-16Dec2015-v1_2015-12-18",
-    "units_per_job": 300,
+    "name": "MuonEG_Run2015D-16Dec2015-v1_2016-03-03",
+    "units_per_job": 100,
     "run_range": [256630, 260627],
     "era": "25ns",
-    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
+    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt "
   },
   "/DoubleMuon/Run2015D-16Dec2015-v1/MINIAOD": {
-    "name": "DoubleMuon_Run2015D-16Dec2015-v1_2015-12-18",
-    "units_per_job": 300,
+    "name": "DoubleMuon_Run2015D-16Dec2015-v1_2016-03-03",
+    "units_per_job": 100,
     "run_range": [256630, 260627],
     "era": "25ns",
-    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
+    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt "
   },
   "/DoubleEG/Run2015D-16Dec2015-v2/MINIAOD": {
-    "name": "DoubleEG_Run2015D-16Dec2015-v2_2015-12-18",
-    "units_per_job": 300,
+    "name": "DoubleEG_Run2015D-16Dec2015-v2_2016-03-03",
+    "units_per_job": 100,
     "run_range": [256630, 260627],
     "era": "25ns",
-    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
+    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_v2.txt "
   }
 }


### PR DESCRIPTION
New JSONs announced today (https://hypernews.cern.ch/HyperNews/CMS/get/physics-validation/2611.html), splitting same as in 74X.
