### PR TITLE
No overlap between dataset and json

### DIFF
--- a/datasets/data_Run2016B.json
+++ b/datasets/data_Run2016B.json
@@ -1,11 +1,4 @@
 {
-  "/MuonEG/Run2016B-PromptReco-v1/MINIAOD": {
-    "name": "MuonEG_Run2016B-PromptReco-v1",
-    "units_per_job": 200,
-    "run_range": [272007, 275376],
-    "era": "25ns",
-    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Cert_271036-279931_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt"
-  },
   "/MuonEG/Run2016B-PromptReco-v2/MINIAOD": {
     "name": "MuonEG_Run2016B-PromptReco-v2",
     "units_per_job": 200,
@@ -13,22 +6,8 @@
     "era": "25ns",
     "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Cert_271036-279931_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt"
   },
-  "/DoubleMuon/Run2016B-PromptReco-v1/MINIAOD": {
-    "name": "DoubleMuon_Run2016B-PromptReco-v1",
-    "units_per_job": 200,
-    "run_range": [272007, 275376],
-    "era": "25ns",
-    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Cert_271036-279931_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt"
-  },
   "/DoubleMuon/Run2016B-PromptReco-v2/MINIAOD": {
     "name": "DoubleMuon_Run2016B-PromptReco-v2",
-    "units_per_job": 200,
-    "run_range": [272007, 275376],
-    "era": "25ns",
-    "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Cert_271036-279931_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt"
-  },
-  "/DoubleEG/Run2016B-PromptReco-v1/MINIAOD": {
-    "name": "DoubleEG_Run2016B-PromptReco-v1",
     "units_per_job": 200,
     "run_range": [272007, 275376],
     "era": "25ns",


### PR DESCRIPTION
Crab jobs are ending with errors of type:

```
The CRAB3 server backend could not submit any job to the Grid scheduler: Splitting task 160919_121957:obondu_crab_MuonEG_Run2016B-PromptReco-v1 on dataset /MuonEG/Run2016B-PromptReco-v1/MINIAOD with LumiBased method does not generate any job
```
