### PR TITLE
First round of Moriond 2017 datasets

### DIFF
--- a/datasets/data_DoubleEG.json
+++ b/datasets/data_DoubleEG.json
@@ -5,7 +5,7 @@
             "units_per_job": 200,
             "run_range": [272007, 275376],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
         "/DoubleEG/Run2016C-23Sep2016-v1/MINIAOD": {
@@ -13,7 +13,7 @@
             "units_per_job": 200,
             "run_range": [275657, 276283],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
         "/DoubleEG/Run2016D-23Sep2016-v1/MINIAOD": {
@@ -21,7 +21,7 @@
             "units_per_job": 200,
             "run_range": [276315, 276811],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -30,7 +30,7 @@
             "units_per_job": 200,
             "run_range": [276831, 277420],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -39,7 +39,7 @@
             "units_per_job": 200,
             "run_range": [277772, 278808],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -48,7 +48,7 @@
             "units_per_job": 200,
             "run_range": [278820, 280385],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -57,7 +57,7 @@
             "units_per_job": 200,
             "run_range": [281207, 284035],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_Prompt_v14",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -66,7 +66,7 @@
             "units_per_job": 200,
             "run_range": [284036, 284068],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_Prompt_v14",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         }
 

--- a/datasets/data_DoubleMuon.json
+++ b/datasets/data_DoubleMuon.json
@@ -5,7 +5,7 @@
             "units_per_job": 200,
             "run_range": [272007, 275376],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -14,7 +14,7 @@
             "units_per_job": 200,
             "run_range": [275657, 276283],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -23,7 +23,7 @@
             "units_per_job": 200,
             "run_range": [276315, 276811],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -32,7 +32,7 @@
             "units_per_job": 200,
             "run_range": [276831, 277420],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -41,7 +41,7 @@
             "units_per_job": 200,
             "run_range": [277772, 278808],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -50,7 +50,7 @@
             "units_per_job": 200,
             "run_range": [278820, 280385],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -59,7 +59,7 @@
             "units_per_job": 200,
             "run_range": [281207, 284035],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_Prompt_v14",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -68,7 +68,7 @@
             "units_per_job": 200,
             "run_range": [284036, 284068],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_Prompt_v14",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         }
     }

--- a/datasets/data_MuonEG.json
+++ b/datasets/data_MuonEG.json
@@ -5,7 +5,7 @@
             "units_per_job": 200,
             "run_range": [272007, 275376],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -14,7 +14,7 @@
             "units_per_job": 200,
             "run_range": [275657, 276283],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -23,7 +23,7 @@
             "units_per_job": 200,
             "run_range": [276315, 276811],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -32,7 +32,7 @@
             "units_per_job": 200,
             "run_range": [276831, 277420],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -41,7 +41,7 @@
             "units_per_job": 200,
             "run_range": [277772, 278808],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -50,7 +50,7 @@
             "units_per_job": 200,
             "run_range": [278820, 280385],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_2016SeptRepro_v4",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -59,7 +59,7 @@
             "units_per_job": 200,
             "run_range": [281207, 284035],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_Prompt_v14",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         },
 
@@ -68,7 +68,7 @@
             "units_per_job": 200,
             "run_range": [284036, 284068],
             "era": "25ns",
-            "globalTag": "80X_dataRun2_Prompt_v14",
+            "globalTag": "80X_dataRun2_2016SeptRepro_v6",
             "certified_lumi_file": "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
         }
     }

--- a/datasets/mc_DY.json
+++ b/datasets/mc_DY.json
@@ -1,11 +1,11 @@
 {
     "DY_NLO": {
-        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Summer16MiniAODv2",
             "era": "25ns"
@@ -13,83 +13,83 @@
     },
 
     "DY_HTbins": {
-        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns",
             "memory": 2500
         },
-        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
             "name": "DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"

--- a/datasets/mc_DY.json
+++ b/datasets/mc_DY.json
@@ -1,97 +1,97 @@
 {
     "DY_NLO": {
-        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "DY_HTbins": {
-        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns",
             "memory": 2500
         },
-        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 2,
-            "name": "DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Spring16MiniAODv2",
+            "name": "DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_ext1_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_QCD.json
+++ b/datasets/mc_QCD.json
@@ -1,46 +1,46 @@
 {
     "QCD_Ptbins_EMEnriched": {
-        "/QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
             "name": "QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Faill15MiniAODv2",
             "era": "25ns"
@@ -48,10 +48,10 @@
     },
 
     "QCD_Ptbins_MuEnriched": {
-        "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_Spring16MiniAODv2",
+            "name": "QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_QCD.json
+++ b/datasets/mc_QCD.json
@@ -1,46 +1,46 @@
 {
     "QCD_Ptbins_EMEnriched": {
-        "/QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "QCD_Pt-15to20_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "QCD_Pt-20to30_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "QCD_Pt-30to50_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "QCD_Pt-50to80_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "QCD_Pt-80to120_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
             "name": "QCD_Pt-120to170_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
             "name": "QCD_Pt-170to300_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
             "name": "QCD_Pt-300toInf_EMEnriched_TuneCUETP8M1_13TeV_pythia8_Faill15MiniAODv2",
             "era": "25ns"
@@ -48,7 +48,7 @@
     },
 
     "QCD_Ptbins_MuEnriched": {
-        "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "QCD_Pt-20toInf_MuEnrichedPt15_TuneCUETP8M1_13TeV_pythia8_Summer16MiniAODv2",

--- a/datasets/mc_SMHiggs.json
+++ b/datasets/mc_SMHiggs.json
@@ -1,129 +1,129 @@
 {
     "SMHiggs": {
 
-        "/VBFHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/VBFHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "VBFHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8_Spring16MiniAODv2",
+            "name": "VBFHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluHToBB_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/GluGluHToBB_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "GluGluHToBB_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "GluGluHToBB_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/HZJ_HToWW_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HZJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "HZJ_HToWW_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "HZJ_HToWW_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/VBFHToBB_M-125_13TeV_powheg_pythia8_weightfix/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/VBFHToBB_M-125_13TeV_powheg_pythia8_weightfix/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "VBFHToBB_M-125_13TeV_powheg_pythia8_weightfix_Spring16MiniAODv2",
+            "name": "VBFHToBB_M-125_13TeV_powheg_pythia8_weightfix_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/HWplusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HWplusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "HWplusJ_HToWW_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "HWplusJ_HToWW_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/bbHToBB_M-125_4FS_ybyt_13TeV_amcatnlo/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/bbHToBB_M-125_4FS_ybyt_13TeV_amcatnlo/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "bbHToBB_M-125_4FS_ybyt_13TeV_amcatnlo_Spring16MiniAODv2",
+            "name": "bbHToBB_M-125_4FS_ybyt_13TeV_amcatnlo_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/GluGluHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "GluGluHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8_Spring16MiniAODv2",
+            "name": "GluGluHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluZH_HToWWTo2L2Nu_ZTo2L_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/GluGluZH_HToWWTo2L2Nu_ZTo2L_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "GluGluZH_HToWWTo2L2Nu_ZTo2L_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "GluGluZH_HToWWTo2L2Nu_ZTo2L_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/bbHToBB_M-125_4FS_yb2_13TeV_amcatnlo/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/bbHToBB_M-125_4FS_yb2_13TeV_amcatnlo/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
-            "name": "bbHToBB_M-125_4FS_yb2_13TeV_amcatnlo_Spring16MiniAODv2",
+            "name": "bbHToBB_M-125_4FS_yb2_13TeV_amcatnlo_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext2-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext2-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/HWminusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HWminusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "HWminusJ_HToWW_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "HWminusJ_HToWW_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
 
     },
 
     "TTH": {
-        "/ttHToNonbb_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ttHToNonbb_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ttHToNonbb_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ttHToNonbb_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ttHTobb_M125_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ttHTobb_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ttHTobb_M125_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ttHTobb_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_SMHiggs.json
+++ b/datasets/mc_SMHiggs.json
@@ -1,109 +1,109 @@
 {
     "SMHiggs": {
 
-        "/VBFHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/VBFHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "VBFHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluHToBB_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/GluGluHToBB_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "GluGluHToBB_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "WplusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/HZJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HZJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "HZJ_HToWW_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/VBFHToBB_M-125_13TeV_powheg_pythia8_weightfix/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/VBFHToBB_M-125_13TeV_powheg_pythia8_weightfix/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "VBFHToBB_M-125_13TeV_powheg_pythia8_weightfix_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/HWplusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HWplusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "HWplusJ_HToWW_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/bbHToBB_M-125_4FS_ybyt_13TeV_amcatnlo/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/bbHToBB_M-125_4FS_ybyt_13TeV_amcatnlo/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "bbHToBB_M-125_4FS_ybyt_13TeV_amcatnlo_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/GluGluHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "GluGluHToWWTo2L2Nu_M125_13TeV_powheg_JHUgen_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluZH_HToWWTo2L2Nu_ZTo2L_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/GluGluZH_HToWWTo2L2Nu_ZTo2L_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "GluGluZH_HToWWTo2L2Nu_ZTo2L_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/bbHToBB_M-125_4FS_yb2_13TeV_amcatnlo/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/bbHToBB_M-125_4FS_yb2_13TeV_amcatnlo/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "bbHToBB_M-125_4FS_yb2_13TeV_amcatnlo_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext2-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_miniAODv2_ext2-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ggZH_HToBB_ZToLL_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ggZH_HToBB_ZToNuNu_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/HWminusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HWminusJ_HToWW_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "HWminusJ_HToWW_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
@@ -113,14 +113,14 @@
     },
 
     "TTH": {
-        "/ttHToNonbb_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ttHToNonbb_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ttHToNonbb_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ttHTobb_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ttHTobb_M125_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ttHTobb_M125_13TeV_powheg_pythia8_Summer16MiniAODv2",

--- a/datasets/mc_SingleTop.json
+++ b/datasets/mc_SingleTop.json
@@ -1,12 +1,12 @@
 {
     "ST_tW_5f_powheg": {
-        "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 3,
             "name": "ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM": {
+        "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM": {
             "units_per_job": 3,
             "name": "ST_tW_top_5f_inclusiveDecays_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
@@ -14,7 +14,7 @@
     },
 
     "ST_t_4f_aMC@NLO": {
-        "/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 3,
             "name": "ST_t-channel_4f_leptonDecays_13TeV-amcatnlo_Summer16MiniAODv2",
@@ -24,7 +24,7 @@
     },
 
     "ST_s_4f_aMC@NLO": {
-        "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 3,
             "name": "ST_s-channel_4f_leptonDecays_13TeV-amcatnlo_Summer16MiniAODv2",
             "era": "25ns"
@@ -32,14 +32,14 @@
     },
 
     "ST_t_4f_powheg": {
-        "/ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
             "name": "ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
             "name": "ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"

--- a/datasets/mc_SingleTop.json
+++ b/datasets/mc_SingleTop.json
@@ -1,47 +1,47 @@
 {
     "ST_tW_5f_powheg": {
-        "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg_Spring16MiniAODv2",
+            "name": "ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM": {
+        "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "ST_tW_top_5f_inclusiveDecays_13TeV-powheg_Spring16MiniAODv2",
+            "name": "ST_tW_top_5f_inclusiveDecays_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "ST_t_4f_aMC@NLO": {
-        "/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 3,
-            "name": "ST_t-channel_4f_leptonDecays_13TeV-amcatnlo_Spring16MiniAODv2",
+            "name": "ST_t-channel_4f_leptonDecays_13TeV-amcatnlo_Summer16MiniAODv2",
             "era": "25ns"
         }
 
     },
 
     "ST_s_4f_aMC@NLO": {
-        "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "ST_s-channel_4f_leptonDecays_13TeV-amcatnlo_Spring16MiniAODv2",
+            "name": "ST_s-channel_4f_leptonDecays_13TeV-amcatnlo_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "ST_t_4f_powheg": {
-        "/ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_Spring16MiniAODv2",
+            "name": "ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_Spring16MiniAODv2",
+            "name": "ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_TT.json
+++ b/datasets/mc_TT.json
@@ -1,50 +1,50 @@
 {
     "TT_powheg_fully_leptonic": {
-        "/TTTo2L2Nu_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/TTTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "TTTo2L2Nu_13TeV-powheg_ext1_Spring16MiniAODv2",
+            "name": "TTTo2L2Nu_13TeV-powheg_ext1_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "TT_powheg_inclusive": {
-        "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext3-v2/MINIAODSIM": {
+        "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext3-v2/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_ext3_Spring16MiniAODv2",
+            "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_ext3_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/MINIAODSIM": {
+        "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_ext4_Spring16MiniAODv2",
+            "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_ext4_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "TT_powheg_newtune_inclusive": {
-        "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "TT_TuneCUETP8M2T4_13TeV-powheg-pythia8_Spring16MiniAODv2",
+            "name": "TT_TuneCUETP8M2T4_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "TT_powheg_inclusive_mtt_binned": {
-        "/TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8_Spring16MiniAODv2",
+            "name": "TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
+        "/TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8_Spring16MiniAODv2",
+            "name": "TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "TT_aMC@NLO_inclusive": {
-        "/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "TTJets_TuneCUETP8M1_amcatnloFXFX_25ns",
@@ -53,24 +53,24 @@
     },
 
     "TTV": {
-        "/TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Spring16MiniAODv2",
+            "name": "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_Spring16MiniAODv2",
+            "name": "TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_Spring16MiniAODv2",
+            "name": "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Spring16MiniAODv2",
+            "name": "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_TT.json
+++ b/datasets/mc_TT.json
@@ -1,6 +1,6 @@
 {
     "TT_powheg_fully_leptonic": {
-        "/TTTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM": {
+        "/TTTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 3,
             "name": "TTTo2L2Nu_13TeV-powheg_ext1_Summer16MiniAODv2",
             "era": "25ns"
@@ -8,14 +8,14 @@
     },
 
     "TT_powheg_inclusive": {
-        "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext3-v2/MINIAODSIM": {
+        "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_ext3_Summer16MiniAODv2",
+            "name": "TT_TuneCUETP8M2T4_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/MINIAODSIM": {
+        "/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext4-v1/MINIAODSIM": {
             "units_per_job": 3,
-            "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_ext4_Summer16MiniAODv2",
+            "name": "TT_TuneCUETP8M2T4_13TeV-powheg-pythia8_ext4_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
@@ -29,48 +29,48 @@
     },
 
     "TT_powheg_inclusive_mtt_binned": {
-        "/TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TT_Mtt-1000toInf_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8_Summer16MiniAODv2",
+            "name": "TT_Mtt-1000toInf_TuneCUETP8M2T4_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
+        "/TT_Mtt-700to1000_TuneCUETP8M2T4_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 5,
-            "name": "TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8_Summer16MiniAODv2",
+            "name": "TT_Mtt-700to1000_TuneCUETP8M2T4_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "TT_aMC@NLO_inclusive": {
-        "/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTJets_TuneCUETP8M2T4_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
-            "name": "TTJets_TuneCUETP8M1_amcatnloFXFX_25ns",
+            "name": "TTJets_TuneCUETP8M2T4_amcatnloFXFX_25ns_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "TTV": {
-        "/TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTZToQQ_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
+            "name": "TTZToQQ_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTWJetsToQQ_TuneCUETP8M2T4_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_Summer16MiniAODv2",
+            "name": "TTWJetsToQQ_TuneCUETP8M2T4_13TeV-amcatnloFXFX-madspin-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTWJetsToLNu_TuneCUETP8M2T4_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_Summer16MiniAODv2",
+            "name": "TTWJetsToLNu_TuneCUETP8M2T4_13TeV-amcatnloFXFX-madspin-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/TTZToLLNuNu_M-10_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 5,
-            "name": "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
+            "name": "TTZToLLNuNu_M-10_TuneCUETP8M2T4_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_VV.json
+++ b/datasets/mc_VV.json
@@ -1,6 +1,6 @@
 {
     "VV": {
-        "/VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
@@ -8,19 +8,19 @@
     },
 
     "ZZ": {
-        "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "ZZTo2L2Nu_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ZZTo4L_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZZTo4L_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "ZZTo4L_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
@@ -28,44 +28,43 @@
     },
 
     "WW": {
-        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WWToLNuQQ_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WWTo2L2Nu_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
-            "comment": "Dataset does not currently exist (07, Jun 2016)",
+        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WWToLNuQQ_13TeV-powheg_Summer16MiniAODv2",
+            "name": "WWToLNuQQ_13TeV-powheg_ext1_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "WZ": {
-        "/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
@@ -73,9 +72,17 @@
     },
 
     "WZZ": {
-        "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
+            "era": "25ns"
+        }
+    },
+
+    "WWZ": {
+        "/WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
+            "units_per_job": 15,
+            "name": "WWZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_VV.json
+++ b/datasets/mc_VV.json
@@ -1,81 +1,81 @@
 {
     "VV": {
-        "/VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8_Spring16MiniAODv2",
+            "name": "VVTo2L2Nu_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "ZZ": {
-        "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "ZZTo2L2Nu_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ZZTo2L2Nu_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ZZTo4L_13TeV_powheg_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZZTo4L_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "ZZTo4L_13TeV_powheg_pythia8_Spring16MiniAODv2",
+            "name": "ZZTo4L_13TeV_powheg_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8_Spring16MiniAODv2",
+            "name": "ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "WW": {
-        "/WWToLNuQQ_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WWToLNuQQ_13TeV-powheg_Spring16MiniAODv2",
+            "name": "WWToLNuQQ_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WWTo2L2Nu_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WWTo2L2Nu_13TeV-powheg_Spring16MiniAODv2",
+            "name": "WWTo2L2Nu_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/WWToLNuQQ_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
+        "/WWToLNuQQ_13TeV-powheg/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_ext1-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
-            "name": "WWToLNuQQ_13TeV-powheg_Spring16MiniAODv2",
+            "name": "WWToLNuQQ_13TeV-powheg_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "WZ": {
-        "/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8_Spring16MiniAODv2",
+            "name": "WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8_Spring16MiniAODv2",
+            "name": "WZTo1L3Nu_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8_Spring16MiniAODv2",
+            "name": "WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         },
 
-        "/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8_Spring16MiniAODv2",
+            "name": "WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "WZZ": {
-        "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Spring16MiniAODv2",
+            "name": "WZZ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/mc_WJets.json
+++ b/datasets/mc_WJets.json
@@ -1,6 +1,6 @@
 {
     "WJets": {
-        "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 15,
             "name": "WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Summer16MiniAODv2",
             "era": "25ns"

--- a/datasets/mc_WJets.json
+++ b/datasets/mc_WJets.json
@@ -1,8 +1,8 @@
 {
     "WJets": {
-        "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "units_per_job": 15,
-            "name": "WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Spring16MiniAODv2",
+            "name": "WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_Summer16MiniAODv2",
             "era": "25ns"
         }
     }

--- a/datasets/signal_HtoZA.json
+++ b/datasets/signal_HtoZA.json
@@ -1,120 +1,120 @@
 {
     "HToZA": {
-        "/HToZATo2L2B_MH-800_MA-200_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-100_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-1000_MA-500_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-1000_MA-500_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-1000_MA-500_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-650_MA-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-650_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-650_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-3000_MA-2000_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-3000_MA-2000_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-3000_MA-2000_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-300_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-300_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-300_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-200_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-200_MA-100_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-200_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-200_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-300_MA-100_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-300_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-300_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-300_MA-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-300_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-300_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-700_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-700_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-700_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-200_MA-50_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-200_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-200_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-300_MA-200_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-300_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-300_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-250_MA-100_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-250_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-250_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-400_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-400_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-400_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-400_13TeV-madgraph-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-400_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-400_13TeV-madgraph_Fall15MiniAODv1",

--- a/datasets/signal_HtoZA.json
+++ b/datasets/signal_HtoZA.json
@@ -1,120 +1,120 @@
 {
     "HToZA": {
-        "/HToZATo2L2B_MH-800_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-1000_MA-500_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-1000_MA-500_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-1000_MA-500_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-650_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-650_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-650_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-3000_MA-2000_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-3000_MA-2000_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-3000_MA-2000_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-300_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-300_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-300_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-1000_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-200_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-200_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-200_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-300_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-300_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-300_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-300_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-300_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-300_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-700_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-700_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-700_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-200_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-200_MA-50_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-200_MA-50_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-300_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-300_MA-200_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-300_MA-200_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-250_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-250_MA-100_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-250_MA-100_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-500_MA-400_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-500_MA-400_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-500_MA-400_13TeV-madgraph_Fall15MiniAODv1",
             "era": "25ns"
         },
-        "/HToZATo2L2B_MH-800_MA-400_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM": {
+        "/HToZATo2L2B_MH-800_MA-400_13TeV-madgraph-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "comment": "Dataset does not currently exist (07, Jun 2016)",
             "units_per_job": 15,
             "name": "HToZATo2L2B_MH-800_MA-400_13TeV-madgraph_Fall15MiniAODv1",

--- a/datasets/signal_ggHH.json
+++ b/datasets/signal_ggHH.json
@@ -1,16 +1,16 @@
 {
     "ggHH_benchmarks": {
-        "/GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph",
             "era": "25ns"
@@ -18,57 +18,57 @@
     },
 
     "ggHH": {
-        "/GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph",
             "era": "25ns"

--- a/datasets/signal_ggHH.json
+++ b/datasets/signal_ggHH.json
@@ -1,16 +1,16 @@
 {
     "ggHH_benchmarks": {
-        "/GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph",
             "era": "25ns"
@@ -18,57 +18,57 @@
     },
 
     "ggHH": {
-        "/GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph",
             "era": "25ns"

--- a/datasets/signal_ggXHH.json
+++ b/datasets/signal_ggXHH.json
@@ -1,17 +1,17 @@
 {
     "ggX0HH_benchmarks": {
 
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph-v2/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_Summer16MiniAODv2",
             "era": "25ns"
@@ -19,57 +19,57 @@
     },
 
     "ggX0HH": {
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v2/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_Summer16MiniAODv2",
             "era": "25ns"
@@ -77,17 +77,17 @@
     },
 
     "ggX2HH_benchmarks": {
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_Summer16MiniAODv2",
             "era": "25ns"
@@ -95,57 +95,57 @@
     },
 
     "ggX2HH": {
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v2/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_Asympt25ns",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_Summer16MiniAODv2",
             "era": "25ns"

--- a/datasets/signal_ggXHH.json
+++ b/datasets/signal_ggXHH.json
@@ -1,153 +1,153 @@
 {
     "ggX0HH_benchmarks": {
 
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_Summer16MiniAODv2",
             "era": "25ns"
         }    
     },
 
     "ggX0HH": {
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v2/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v2/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_Spring16MiniAODv2",
+            "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "ggX2HH_benchmarks": {
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_Summer16MiniAODv2",
             "era": "25ns"
         }
     },
 
     "ggX2HH": {
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v2/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v2/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
             "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_Asympt25ns",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_Summer16MiniAODv2",
             "era": "25ns"
         },
-        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
+        "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISummer16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM": {
             "units_per_job": 1,
-            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_Spring16MiniAODv2",
+            "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_Summer16MiniAODv2",
             "era": "25ns"
         }
     }


### PR DESCRIPTION
It's mostly just renaming of the old samples into the new naming scheme. Most of the samples do not exist for the moment, but some are already there.

@OlivierBondu If I get it right, the signal sample must be renamed from `madgraph` to `madgraph-v2` for the new production with the taus, is that correct?